### PR TITLE
Draft: Dynamic Signer and KeysManager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,7 +256,6 @@ checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
 [[package]]
 name = "lightning"
 version = "0.0.13"
-source = "git+https://github.com/rust-bitcoin/rust-lightning?rev=32f6205848806a3b2876a2ae36b1db7d5fa22f7d#32f6205848806a3b2876a2ae36b1db7d5fa22f7d"
 dependencies = [
  "bitcoin",
 ]
@@ -264,7 +263,6 @@ dependencies = [
 [[package]]
 name = "lightning-background-processor"
 version = "0.0.13"
-source = "git+https://github.com/rust-bitcoin/rust-lightning?rev=32f6205848806a3b2876a2ae36b1db7d5fa22f7d#32f6205848806a3b2876a2ae36b1db7d5fa22f7d"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -274,7 +272,6 @@ dependencies = [
 [[package]]
 name = "lightning-block-sync"
 version = "0.0.13"
-source = "git+https://github.com/rust-bitcoin/rust-lightning?rev=32f6205848806a3b2876a2ae36b1db7d5fa22f7d#32f6205848806a3b2876a2ae36b1db7d5fa22f7d"
 dependencies = [
  "bitcoin",
  "chunked_transfer",
@@ -298,7 +295,6 @@ dependencies = [
 [[package]]
 name = "lightning-net-tokio"
 version = "0.0.13"
-source = "git+https://github.com/rust-bitcoin/rust-lightning?rev=32f6205848806a3b2876a2ae36b1db7d5fa22f7d#32f6205848806a3b2876a2ae36b1db7d5fa22f7d"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -308,7 +304,6 @@ dependencies = [
 [[package]]
 name = "lightning-persister"
 version = "0.0.13"
-source = "git+https://github.com/rust-bitcoin/rust-lightning?rev=32f6205848806a3b2876a2ae36b1db7d5fa22f7d#32f6205848806a3b2876a2ae36b1db7d5fa22f7d"
 dependencies = [
  "bitcoin",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,17 +8,17 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-lightning-background-processor = { git = "https://github.com/rust-bitcoin/rust-lightning", rev = "32f6205848806a3b2876a2ae36b1db7d5fa22f7d" }
+lightning-background-processor = { path = "../../rust-lightning/background-processor" }
 base64 = "0.13.0"
 bitcoin = "0.26"
 bitcoin-bech32 = "0.7"
 bech32 = "0.7"
 hex = "0.3"
-lightning = { git = "https://github.com/rust-bitcoin/rust-lightning", rev = "32f6205848806a3b2876a2ae36b1db7d5fa22f7d" }
-lightning-block-sync = { git = "https://github.com/rust-bitcoin/rust-lightning", features = ["rpc-client"], rev = "32f6205848806a3b2876a2ae36b1db7d5fa22f7d" }
+lightning = { path = "../../rust-lightning/lightning" }
+lightning-block-sync = { path = "../../rust-lightning/lightning-block-sync", features = ["rpc-client"] }
 lightning-invoice = { git = "https://github.com/rust-bitcoin/rust-lightning-invoice", rev = "aa3a57b9dca5205fa25fa333a2db165d7e77b3b0" }
-lightning-net-tokio = { git = "https://github.com/rust-bitcoin/rust-lightning", rev = "32f6205848806a3b2876a2ae36b1db7d5fa22f7d" }
-lightning-persister = { git = "https://github.com/rust-bitcoin/rust-lightning", rev = "32f6205848806a3b2876a2ae36b1db7d5fa22f7d" }
+lightning-net-tokio = { path = "../../rust-lightning/lightning-net-tokio" }
+lightning-persister = { path = "../../rust-lightning/lightning-persister" }
 time = "0.2"
 rand = "0.4"
 serde_json = { version = "1.0" }

--- a/src/byte_utils.rs
+++ b/src/byte_utils.rs
@@ -1,0 +1,135 @@
+// This file is Copyright its original authors, visible in version control
+// history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+#[inline]
+pub fn slice_to_be16(v: &[u8]) -> u16 {
+	((v[0] as u16) << 8*1) |
+	((v[1] as u16) << 8*0)
+}
+#[inline]
+pub fn slice_to_be32(v: &[u8]) -> u32 {
+	((v[0] as u32) << 8*3) |
+	((v[1] as u32) << 8*2) |
+	((v[2] as u32) << 8*1) |
+	((v[3] as u32) << 8*0)
+}
+#[cfg(not(feature = "fuzztarget"))] // Used only by poly1305
+#[inline]
+pub fn slice_to_le32(v: &[u8]) -> u32 {
+	((v[0] as u32) << 8*0) |
+	((v[1] as u32) << 8*1) |
+	((v[2] as u32) << 8*2) |
+	((v[3] as u32) << 8*3)
+}
+#[inline]
+pub fn slice_to_be48(v: &[u8]) -> u64 {
+	((v[0] as u64) << 8*5) |
+	((v[1] as u64) << 8*4) |
+	((v[2] as u64) << 8*3) |
+	((v[3] as u64) << 8*2) |
+	((v[4] as u64) << 8*1) |
+	((v[5] as u64) << 8*0)
+}
+#[inline]
+pub fn slice_to_be64(v: &[u8]) -> u64 {
+	((v[0] as u64) << 8*7) |
+	((v[1] as u64) << 8*6) |
+	((v[2] as u64) << 8*5) |
+	((v[3] as u64) << 8*4) |
+	((v[4] as u64) << 8*3) |
+	((v[5] as u64) << 8*2) |
+	((v[6] as u64) << 8*1) |
+	((v[7] as u64) << 8*0)
+}
+
+#[inline]
+pub fn be16_to_array(u: u16) -> [u8; 2] {
+	let mut v = [0; 2];
+	v[0] = ((u >> 8*1) & 0xff) as u8;
+	v[1] = ((u >> 8*0) & 0xff) as u8;
+	v
+}
+#[inline]
+pub fn be32_to_array(u: u32) -> [u8; 4] {
+	let mut v = [0; 4];
+	v[0] = ((u >> 8*3) & 0xff) as u8;
+	v[1] = ((u >> 8*2) & 0xff) as u8;
+	v[2] = ((u >> 8*1) & 0xff) as u8;
+	v[3] = ((u >> 8*0) & 0xff) as u8;
+	v
+}
+#[cfg(not(feature = "fuzztarget"))] // Used only by poly1305
+#[inline]
+pub fn le32_to_array(u: u32) -> [u8; 4] {
+	let mut v = [0; 4];
+	v[0] = ((u >> 8*0) & 0xff) as u8;
+	v[1] = ((u >> 8*1) & 0xff) as u8;
+	v[2] = ((u >> 8*2) & 0xff) as u8;
+	v[3] = ((u >> 8*3) & 0xff) as u8;
+	v
+}
+#[inline]
+pub fn be48_to_array(u: u64) -> [u8; 6] {
+	assert!(u & 0xffff_0000_0000_0000 == 0);
+	let mut v = [0; 6];
+	v[0] = ((u >> 8*5) & 0xff) as u8;
+	v[1] = ((u >> 8*4) & 0xff) as u8;
+	v[2] = ((u >> 8*3) & 0xff) as u8;
+	v[3] = ((u >> 8*2) & 0xff) as u8;
+	v[4] = ((u >> 8*1) & 0xff) as u8;
+	v[5] = ((u >> 8*0) & 0xff) as u8;
+	v
+}
+#[inline]
+pub fn be64_to_array(u: u64) -> [u8; 8] {
+	let mut v = [0; 8];
+	v[0] = ((u >> 8*7) & 0xff) as u8;
+	v[1] = ((u >> 8*6) & 0xff) as u8;
+	v[2] = ((u >> 8*5) & 0xff) as u8;
+	v[3] = ((u >> 8*4) & 0xff) as u8;
+	v[4] = ((u >> 8*3) & 0xff) as u8;
+	v[5] = ((u >> 8*2) & 0xff) as u8;
+	v[6] = ((u >> 8*1) & 0xff) as u8;
+	v[7] = ((u >> 8*0) & 0xff) as u8;
+	v
+}
+
+#[inline]
+pub fn le64_to_array(u: u64) -> [u8; 8] {
+	let mut v = [0; 8];
+	v[0] = ((u >> 8*0) & 0xff) as u8;
+	v[1] = ((u >> 8*1) & 0xff) as u8;
+	v[2] = ((u >> 8*2) & 0xff) as u8;
+	v[3] = ((u >> 8*3) & 0xff) as u8;
+	v[4] = ((u >> 8*4) & 0xff) as u8;
+	v[5] = ((u >> 8*5) & 0xff) as u8;
+	v[6] = ((u >> 8*6) & 0xff) as u8;
+	v[7] = ((u >> 8*7) & 0xff) as u8;
+	v
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	
+	#[test]
+	fn test_all() {
+		assert_eq!(slice_to_be16(&[0xde, 0xad]), 0xdead);
+		assert_eq!(slice_to_be32(&[0xde, 0xad, 0xbe, 0xef]), 0xdeadbeef);
+		assert_eq!(slice_to_le32(&[0xef, 0xbe, 0xad, 0xde]), 0xdeadbeef);
+		assert_eq!(slice_to_be48(&[0xde, 0xad, 0xbe, 0xef, 0x1b, 0xad]), 0xdeadbeef1bad);
+		assert_eq!(slice_to_be64(&[0xde, 0xad, 0xbe, 0xef, 0x1b, 0xad, 0x1d, 0xea]), 0xdeadbeef1bad1dea);
+		assert_eq!(be16_to_array(0xdead), [0xde, 0xad]);
+		assert_eq!(be32_to_array(0xdeadbeef), [0xde, 0xad, 0xbe, 0xef]);
+		assert_eq!(le32_to_array(0xdeadbeef), [0xef, 0xbe, 0xad, 0xde]);
+		assert_eq!(be48_to_array(0xdeadbeef1bad), [0xde, 0xad, 0xbe, 0xef, 0x1b, 0xad]);
+		assert_eq!(be64_to_array(0xdeadbeef1bad1dea), [0xde, 0xad, 0xbe, 0xef, 0x1b, 0xad, 0x1d, 0xea]);
+		assert_eq!(le64_to_array(0xdeadbeef1bad1dea), [0xea, 0x1d, 0xad, 0x1b, 0xef, 0xbe, 0xad, 0xde]);
+	}
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -28,6 +28,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::runtime::Handle;
 use tokio::sync::mpsc;
+use lightning::chain::keysinterface::{Sign, KeysInterface};
 
 pub(crate) struct LdkUserInfo {
 	pub(crate) bitcoind_rpc_username: String,
@@ -98,8 +99,8 @@ pub(crate) fn parse_startup_args() -> Result<LdkUserInfo, ()> {
 	})
 }
 
-pub(crate) fn poll_for_user_input(
-	peer_manager: Arc<PeerManager>, channel_manager: Arc<ChannelManager>,
+pub(crate) fn poll_for_user_input<S: Sign + Sync, M: KeysInterface<Signer=S>>(
+	peer_manager: Arc<PeerManager<S>>, channel_manager: Arc<ChannelManager<S, M>>,
 	router: Arc<NetGraphMsgHandler<Arc<dyn chain::Access>, Arc<FilesystemLogger>>>,
 	payment_storage: PaymentInfoStorage, node_privkey: SecretKey, event_notifier: mpsc::Sender<()>,
 	ldk_data_dir: String, logger: Arc<FilesystemLogger>, runtime_handle: Handle, network: Network,
@@ -394,7 +395,7 @@ fn help() {
 	println!("forceclosechannel <channel_id>");
 }
 
-fn list_channels(channel_manager: Arc<ChannelManager>) {
+fn list_channels<S: Sign + Sync, M: KeysInterface<Signer=S>>(channel_manager: Arc<ChannelManager<S, M>>) {
 	print!("[");
 	for chan_info in channel_manager.list_channels() {
 		println!("");
@@ -446,8 +447,8 @@ fn list_payments(payment_storage: PaymentInfoStorage) {
 	println!("]");
 }
 
-pub(crate) fn connect_peer_if_necessary(
-	pubkey: PublicKey, peer_addr: SocketAddr, peer_manager: Arc<PeerManager>,
+pub(crate) fn connect_peer_if_necessary<S: Sign + Sync>(
+	pubkey: PublicKey, peer_addr: SocketAddr, peer_manager: Arc<PeerManager<S>>,
 	event_notifier: mpsc::Sender<()>, runtime: Handle,
 ) -> Result<(), ()> {
 	for node_pubkey in peer_manager.get_peer_node_ids() {
@@ -479,9 +480,9 @@ pub(crate) fn connect_peer_if_necessary(
 	Ok(())
 }
 
-fn open_channel(
+fn open_channel<S: Sign + Sync, M: KeysInterface<Signer=S>>(
 	peer_pubkey: PublicKey, channel_amt_sat: u64, announce_channel: bool,
-	channel_manager: Arc<ChannelManager>,
+	channel_manager: Arc<ChannelManager<S, M>>,
 ) -> Result<(), ()> {
 	let mut config = UserConfig::default();
 	if announce_channel {
@@ -501,11 +502,11 @@ fn open_channel(
 	}
 }
 
-fn send_payment(
+fn send_payment<S: Sign + Sync, M: KeysInterface<Signer=S>>(
 	payee: PublicKey, amt_msat: u64, final_cltv: u32, payment_hash: PaymentHash,
 	payment_secret: Option<PaymentSecret>, payee_features: Option<InvoiceFeatures>,
 	router: Arc<NetGraphMsgHandler<Arc<dyn chain::Access>, Arc<FilesystemLogger>>>,
-	channel_manager: Arc<ChannelManager>, payment_storage: PaymentInfoStorage,
+	channel_manager: Arc<ChannelManager<S, M>>, payment_storage: PaymentInfoStorage,
 	logger: Arc<FilesystemLogger>,
 ) {
 	let network_graph = router.network_graph.read().unwrap();
@@ -545,9 +546,9 @@ fn send_payment(
 	);
 }
 
-fn get_invoice(
+fn get_invoice<S: Sign + Sync, M: KeysInterface<Signer=S>>(
 	amt_sat: u64, payment_storage: PaymentInfoStorage, our_node_privkey: SecretKey,
-	channel_manager: Arc<ChannelManager>, network: Network,
+	channel_manager: Arc<ChannelManager<S, M>>, network: Network,
 ) {
 	let mut payments = payment_storage.lock().unwrap();
 	let secp_ctx = Secp256k1::new();
@@ -610,14 +611,14 @@ fn get_invoice(
 	);
 }
 
-fn close_channel(channel_id: [u8; 32], channel_manager: Arc<ChannelManager>) {
+fn close_channel<S: Sign + Sync, M: KeysInterface<Signer=S>>(channel_id: [u8; 32], channel_manager: Arc<ChannelManager<S, M>>) {
 	match channel_manager.close_channel(&channel_id) {
 		Ok(()) => println!("EVENT: initiating channel close"),
 		Err(e) => println!("ERROR: failed to close channel: {:?}", e),
 	}
 }
 
-fn force_close_channel(channel_id: [u8; 32], channel_manager: Arc<ChannelManager>) {
+fn force_close_channel<S: Sign + Sync, M: KeysInterface<Signer=S>>(channel_id: [u8; 32], channel_manager: Arc<ChannelManager<S, M>>) {
 	match channel_manager.force_close_channel(&channel_id) {
 		Ok(()) => println!("EVENT: initiating channel force-close"),
 		Err(e) => println!("ERROR: failed to force-close channel: {:?}", e),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -99,7 +99,7 @@ pub(crate) fn parse_startup_args() -> Result<LdkUserInfo, ()> {
 	})
 }
 
-pub(crate) fn poll_for_user_input<S: 'static + Sign + Sync, M: 'static + KeysInterface<Signer=S>>(
+pub(crate) fn poll_for_user_input<S: 'static + Sign+Sync+Clone, M: 'static + KeysInterface<Signer=S>>(
 	peer_manager: Arc<PeerManager<S, M>>, channel_manager: Arc<ChannelManager<S, M>>,
 	router: Arc<NetGraphMsgHandler<Arc<dyn chain::Access>, Arc<FilesystemLogger>>>,
 	payment_storage: PaymentInfoStorage, node_privkey: SecretKey, event_notifier: mpsc::Sender<()>,
@@ -395,7 +395,7 @@ fn help() {
 	println!("forceclosechannel <channel_id>");
 }
 
-fn list_channels<S: Sign + Sync, M: KeysInterface<Signer=S>>(channel_manager: Arc<ChannelManager<S, M>>) {
+fn list_channels<S: Sign+Sync+Clone, M: KeysInterface<Signer=S>>(channel_manager: Arc<ChannelManager<S, M>>) {
 	print!("[");
 	for chan_info in channel_manager.list_channels() {
 		println!("");
@@ -447,7 +447,7 @@ fn list_payments(payment_storage: PaymentInfoStorage) {
 	println!("]");
 }
 
-pub(crate) fn connect_peer_if_necessary<S: 'static + Sign + Sync, M: 'static + KeysInterface<Signer=S>>(
+pub(crate) fn connect_peer_if_necessary<S: 'static + Sign+Sync+Clone, M: 'static + KeysInterface<Signer=S>>(
 	pubkey: PublicKey, peer_addr: SocketAddr, peer_manager: Arc<PeerManager<S, M>>,
 	event_notifier: mpsc::Sender<()>, runtime: Handle,
 ) -> Result<(), ()> {
@@ -480,7 +480,7 @@ pub(crate) fn connect_peer_if_necessary<S: 'static + Sign + Sync, M: 'static + K
 	Ok(())
 }
 
-fn open_channel<S: Sign + Sync, M: KeysInterface<Signer=S>>(
+fn open_channel<S: Sign+Sync+Clone, M: KeysInterface<Signer=S>>(
 	peer_pubkey: PublicKey, channel_amt_sat: u64, announce_channel: bool,
 	channel_manager: Arc<ChannelManager<S, M>>,
 ) -> Result<(), ()> {
@@ -502,7 +502,7 @@ fn open_channel<S: Sign + Sync, M: KeysInterface<Signer=S>>(
 	}
 }
 
-fn send_payment<S: Sign + Sync, M: KeysInterface<Signer=S>>(
+fn send_payment<S: Sign+Sync+Clone, M: KeysInterface<Signer=S>>(
 	payee: PublicKey, amt_msat: u64, final_cltv: u32, payment_hash: PaymentHash,
 	payment_secret: Option<PaymentSecret>, payee_features: Option<InvoiceFeatures>,
 	router: Arc<NetGraphMsgHandler<Arc<dyn chain::Access>, Arc<FilesystemLogger>>>,
@@ -546,7 +546,7 @@ fn send_payment<S: Sign + Sync, M: KeysInterface<Signer=S>>(
 	);
 }
 
-fn get_invoice<S: Sign + Sync, M: KeysInterface<Signer=S>>(
+fn get_invoice<S: Sign+Sync+Clone, M: KeysInterface<Signer=S>>(
 	amt_sat: u64, payment_storage: PaymentInfoStorage, our_node_privkey: SecretKey,
 	channel_manager: Arc<ChannelManager<S, M>>, network: Network,
 ) {
@@ -611,14 +611,14 @@ fn get_invoice<S: Sign + Sync, M: KeysInterface<Signer=S>>(
 	);
 }
 
-fn close_channel<S: Sign + Sync, M: KeysInterface<Signer=S>>(channel_id: [u8; 32], channel_manager: Arc<ChannelManager<S, M>>) {
+fn close_channel<S: Sign+Sync+Clone, M: KeysInterface<Signer=S>>(channel_id: [u8; 32], channel_manager: Arc<ChannelManager<S, M>>) {
 	match channel_manager.close_channel(&channel_id) {
 		Ok(()) => println!("EVENT: initiating channel close"),
 		Err(e) => println!("ERROR: failed to close channel: {:?}", e),
 	}
 }
 
-fn force_close_channel<S: Sign + Sync, M: KeysInterface<Signer=S>>(channel_id: [u8; 32], channel_manager: Arc<ChannelManager<S, M>>) {
+fn force_close_channel<S: Sign+Sync+Clone, M: KeysInterface<Signer=S>>(channel_id: [u8; 32], channel_manager: Arc<ChannelManager<S, M>>) {
 	match channel_manager.force_close_channel(&channel_id) {
 		Ok(()) => println!("EVENT: initiating channel force-close"),
 		Err(e) => println!("ERROR: failed to force-close channel: {:?}", e),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -28,7 +28,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::runtime::Handle;
 use tokio::sync::mpsc;
-use lightning::chain::keysinterface::{Sign, KeysInterface};
+use crate::keys::DynKeysInterface;
 
 pub(crate) struct LdkUserInfo {
 	pub(crate) bitcoind_rpc_username: String,
@@ -99,8 +99,8 @@ pub(crate) fn parse_startup_args() -> Result<LdkUserInfo, ()> {
 	})
 }
 
-pub(crate) fn poll_for_user_input<S: 'static + Sign+Sync+Clone, M: 'static + KeysInterface<Signer=S>>(
-	peer_manager: Arc<PeerManager<S, M>>, channel_manager: Arc<ChannelManager<S, M>>,
+pub(crate) fn poll_for_user_input<M: 'static + DynKeysInterface>(
+	peer_manager: Arc<PeerManager<M>>, channel_manager: Arc<ChannelManager<M>>,
 	router: Arc<NetGraphMsgHandler<Arc<dyn chain::Access>, Arc<FilesystemLogger>>>,
 	payment_storage: PaymentInfoStorage, node_privkey: SecretKey, event_notifier: mpsc::Sender<()>,
 	ldk_data_dir: String, logger: Arc<FilesystemLogger>, runtime_handle: Handle, network: Network,
@@ -395,7 +395,7 @@ fn help() {
 	println!("forceclosechannel <channel_id>");
 }
 
-fn list_channels<S: Sign+Sync+Clone, M: KeysInterface<Signer=S>>(channel_manager: Arc<ChannelManager<S, M>>) {
+fn list_channels<M: DynKeysInterface>(channel_manager: Arc<ChannelManager<M>>) {
 	print!("[");
 	for chan_info in channel_manager.list_channels() {
 		println!("");
@@ -447,8 +447,8 @@ fn list_payments(payment_storage: PaymentInfoStorage) {
 	println!("]");
 }
 
-pub(crate) fn connect_peer_if_necessary<S: 'static + Sign+Sync+Clone, M: 'static + KeysInterface<Signer=S>>(
-	pubkey: PublicKey, peer_addr: SocketAddr, peer_manager: Arc<PeerManager<S, M>>,
+pub(crate) fn connect_peer_if_necessary<M: 'static + DynKeysInterface>(
+	pubkey: PublicKey, peer_addr: SocketAddr, peer_manager: Arc<PeerManager<M>>,
 	event_notifier: mpsc::Sender<()>, runtime: Handle,
 ) -> Result<(), ()> {
 	for node_pubkey in peer_manager.get_peer_node_ids() {
@@ -480,9 +480,9 @@ pub(crate) fn connect_peer_if_necessary<S: 'static + Sign+Sync+Clone, M: 'static
 	Ok(())
 }
 
-fn open_channel<S: Sign+Sync+Clone, M: KeysInterface<Signer=S>>(
+fn open_channel<M: DynKeysInterface>(
 	peer_pubkey: PublicKey, channel_amt_sat: u64, announce_channel: bool,
-	channel_manager: Arc<ChannelManager<S, M>>,
+	channel_manager: Arc<ChannelManager<M>>,
 ) -> Result<(), ()> {
 	let mut config = UserConfig::default();
 	if announce_channel {
@@ -502,11 +502,11 @@ fn open_channel<S: Sign+Sync+Clone, M: KeysInterface<Signer=S>>(
 	}
 }
 
-fn send_payment<S: Sign+Sync+Clone, M: KeysInterface<Signer=S>>(
+fn send_payment<M: DynKeysInterface>(
 	payee: PublicKey, amt_msat: u64, final_cltv: u32, payment_hash: PaymentHash,
 	payment_secret: Option<PaymentSecret>, payee_features: Option<InvoiceFeatures>,
 	router: Arc<NetGraphMsgHandler<Arc<dyn chain::Access>, Arc<FilesystemLogger>>>,
-	channel_manager: Arc<ChannelManager<S, M>>, payment_storage: PaymentInfoStorage,
+	channel_manager: Arc<ChannelManager<M>>, payment_storage: PaymentInfoStorage,
 	logger: Arc<FilesystemLogger>,
 ) {
 	let network_graph = router.network_graph.read().unwrap();
@@ -546,9 +546,9 @@ fn send_payment<S: Sign+Sync+Clone, M: KeysInterface<Signer=S>>(
 	);
 }
 
-fn get_invoice<S: Sign+Sync+Clone, M: KeysInterface<Signer=S>>(
+fn get_invoice<M: DynKeysInterface>(
 	amt_sat: u64, payment_storage: PaymentInfoStorage, our_node_privkey: SecretKey,
-	channel_manager: Arc<ChannelManager<S, M>>, network: Network,
+	channel_manager: Arc<ChannelManager<M>>, network: Network,
 ) {
 	let mut payments = payment_storage.lock().unwrap();
 	let secp_ctx = Secp256k1::new();
@@ -611,14 +611,14 @@ fn get_invoice<S: Sign+Sync+Clone, M: KeysInterface<Signer=S>>(
 	);
 }
 
-fn close_channel<S: Sign+Sync+Clone, M: KeysInterface<Signer=S>>(channel_id: [u8; 32], channel_manager: Arc<ChannelManager<S, M>>) {
+fn close_channel<M: DynKeysInterface>(channel_id: [u8; 32], channel_manager: Arc<ChannelManager<M>>) {
 	match channel_manager.close_channel(&channel_id) {
 		Ok(()) => println!("EVENT: initiating channel close"),
 		Err(e) => println!("ERROR: failed to close channel: {:?}", e),
 	}
 }
 
-fn force_close_channel<S: Sign+Sync+Clone, M: KeysInterface<Signer=S>>(channel_id: [u8; 32], channel_manager: Arc<ChannelManager<S, M>>) {
+fn force_close_channel<M: DynKeysInterface>(channel_id: [u8; 32], channel_manager: Arc<ChannelManager<M>>) {
 	match channel_manager.force_close_channel(&channel_id) {
 		Ok(()) => println!("EVENT: initiating channel force-close"),
 		Err(e) => println!("ERROR: failed to force-close channel: {:?}", e),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -99,8 +99,8 @@ pub(crate) fn parse_startup_args() -> Result<LdkUserInfo, ()> {
 	})
 }
 
-pub(crate) fn poll_for_user_input<S: Sign + Sync, M: KeysInterface<Signer=S>>(
-	peer_manager: Arc<PeerManager<S>>, channel_manager: Arc<ChannelManager<S, M>>,
+pub(crate) fn poll_for_user_input<S: 'static + Sign + Sync, M: 'static + KeysInterface<Signer=S>>(
+	peer_manager: Arc<PeerManager<S, M>>, channel_manager: Arc<ChannelManager<S, M>>,
 	router: Arc<NetGraphMsgHandler<Arc<dyn chain::Access>, Arc<FilesystemLogger>>>,
 	payment_storage: PaymentInfoStorage, node_privkey: SecretKey, event_notifier: mpsc::Sender<()>,
 	ldk_data_dir: String, logger: Arc<FilesystemLogger>, runtime_handle: Handle, network: Network,
@@ -447,8 +447,8 @@ fn list_payments(payment_storage: PaymentInfoStorage) {
 	println!("]");
 }
 
-pub(crate) fn connect_peer_if_necessary<S: Sign + Sync>(
-	pubkey: PublicKey, peer_addr: SocketAddr, peer_manager: Arc<PeerManager<S>>,
+pub(crate) fn connect_peer_if_necessary<S: 'static + Sign + Sync, M: 'static + KeysInterface<Signer=S>>(
+	pubkey: PublicKey, peer_addr: SocketAddr, peer_manager: Arc<PeerManager<S, M>>,
 	event_notifier: mpsc::Sender<()>, runtime: Handle,
 ) -> Result<(), ()> {
 	for node_pubkey in peer_manager.get_peer_node_ids() {

--- a/src/default_signer.rs
+++ b/src/default_signer.rs
@@ -1,0 +1,95 @@
+use crate::byte_utils;
+use bitcoin::secp256k1::{SecretKey, Secp256k1, All};
+use bitcoin::util::bip32::{ChildNumber, ExtendedPrivKey};
+use lightning::chain::keysinterface::{InMemorySigner, StaticPaymentOutputDescriptor, DelayedPaymentOutputDescriptor};
+use bitcoin::hashes::sha256::Hash as Sha256;
+use bitcoin::hashes::{Hash, HashEngine};
+use crate::keys::{SignerFactory, DynSigner, PaymentSign, InnerSign};
+use bitcoin::Transaction;
+
+// XXX This file helps main() put together the world with InMemorySigner
+
+pub struct InMemorySignerFactory {
+    seed: [u8; 32],
+    secp_ctx: Secp256k1<All>,
+}
+
+impl InMemorySignerFactory {
+    pub fn new(seed: &[u8; 32]) -> Self {
+        InMemorySignerFactory {
+            seed: seed.clone(),
+            secp_ctx: Secp256k1::new(),
+        }
+    }
+}
+
+impl PaymentSign for InMemorySigner {
+    fn sign_counterparty_payment_input_t(&self, spend_tx: &Transaction, input_idx: usize, descriptor: &StaticPaymentOutputDescriptor, secp_ctx: &Secp256k1<All>) -> Result<Vec<Vec<u8>>, ()> {
+        self.sign_counterparty_payment_input(spend_tx, input_idx, descriptor, secp_ctx)
+    }
+
+    fn sign_dynamic_p2wsh_input_t(&self, spend_tx: &Transaction, input_idx: usize, descriptor: &DelayedPaymentOutputDescriptor, secp_ctx: &Secp256k1<All>) -> Result<Vec<Vec<u8>>, ()> {
+        self.sign_dynamic_p2wsh_input(spend_tx, input_idx, descriptor, secp_ctx)
+    }
+}
+
+impl InnerSign for InMemorySigner {
+    fn box_clone(&self) -> Box<dyn InnerSign + Sync> {
+        Box::new(self.clone())
+    }
+}
+
+impl SignerFactory for InMemorySignerFactory {
+    fn derive_channel_keys(&self, channel_master_key: &ExtendedPrivKey, channel_value_satoshis: u64, params: &[u8; 32]) -> DynSigner {
+        let chan_id = byte_utils::slice_to_be64(&params[0..8]);
+        assert!(chan_id <= std::u32::MAX as u64); // Otherwise the params field wasn't created by us
+        let mut unique_start = Sha256::engine();
+        unique_start.input(params);
+        unique_start.input(&self.seed);
+
+        // We only seriously intend to rely on the channel_master_key for true secure
+        // entropy, everything else just ensures uniqueness. We rely on the unique_start (ie
+        // starting_time provided in the constructor) to be unique.
+        let child_privkey = channel_master_key.ckd_priv(&self.secp_ctx, ChildNumber::from_hardened_idx(chan_id as u32).expect("key space exhausted")).expect("Your RNG is busted");
+        unique_start.input(&child_privkey.private_key.key[..]);
+
+        let seed = Sha256::from_engine(unique_start).into_inner();
+
+        let commitment_seed = {
+            let mut sha = Sha256::engine();
+            sha.input(&seed);
+            sha.input(&b"commitment seed"[..]);
+            Sha256::from_engine(sha).into_inner()
+        };
+        macro_rules! key_step {
+			($info: expr, $prev_key: expr) => {{
+				let mut sha = Sha256::engine();
+				sha.input(&seed);
+				sha.input(&$prev_key[..]);
+				sha.input(&$info[..]);
+				SecretKey::from_slice(&Sha256::from_engine(sha).into_inner()).expect("SHA-256 is busted")
+			}}
+		}
+        let funding_key = key_step!(b"funding key", commitment_seed);
+        let revocation_base_key = key_step!(b"revocation base key", funding_key);
+        let payment_key = key_step!(b"payment key", revocation_base_key);
+        let delayed_payment_base_key = key_step!(b"delayed payment base key", payment_key);
+        let htlc_base_key = key_step!(b"HTLC base key", delayed_payment_base_key);
+
+        let signer = InMemorySigner::new(
+            &self.secp_ctx,
+            funding_key,
+            revocation_base_key,
+            payment_key,
+            delayed_payment_base_key,
+            htlc_base_key,
+            commitment_seed,
+            channel_value_satoshis,
+            params.clone()
+        );
+
+        DynSigner {
+            inner: Box::new(signer)
+        }
+    }
+}

--- a/src/default_signer.rs
+++ b/src/default_signer.rs
@@ -34,7 +34,7 @@ impl PaymentSign for InMemorySigner {
 }
 
 impl InnerSign for InMemorySigner {
-    fn box_clone(&self) -> Box<dyn InnerSign + Sync> {
+    fn box_clone(&self) -> Box<dyn InnerSign> {
         Box::new(self.clone())
     }
 }

--- a/src/disk.rs
+++ b/src/disk.rs
@@ -6,12 +6,12 @@ use lightning::chain::channelmonitor::ChannelMonitor;
 use lightning::chain::keysinterface::{KeysInterface, Sign};
 use lightning::chain::transaction::OutPoint;
 use lightning::util::logger::{Logger, Record};
-use lightning::util::ser::{ReadableArgs, Writer};
+use lightning::util::ser::ReadableArgs;
 use std::collections::HashMap;
 use std::fs;
 use std::fs::File;
 // use std::io::{BufRead, BufReader, Cursor, Write};
-use std::io::{BufRead, BufReader, Cursor};
+use std::io::{BufRead, BufReader, Cursor, Write};
 use std::net::SocketAddr;
 use std::path::Path;
 use std::sync::Arc;
@@ -73,7 +73,7 @@ pub(crate) fn read_channel_peer_data(
 	Ok(peer_data)
 }
 
-pub(crate) fn read_channelmonitors<S: Sign, M: KeysInterface<Signer=S>>(
+pub(crate) fn read_channelmonitors<S: Sign+Clone, M: KeysInterface<Signer=S>>(
 	path: String, keys_manager: Arc<M>,
 ) -> Result<HashMap<OutPoint, (BlockHash, ChannelMonitor<S>)>, std::io::Error> {
 	if !Path::new(&path).exists() {

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,0 +1,419 @@
+use bitcoin::secp256k1;
+use bitcoin::secp256k1::{Secp256k1, SecretKey, PublicKey, Signing, Signature};
+use bitcoin::hashes::sha256::HashEngine as Sha256State;
+use bitcoin::hashes::sha256::Hash as Sha256;
+use bitcoin::{Script, Network, TxOut, Transaction, TxIn, SigHashType};
+use bitcoin::util::bip32::{ExtendedPrivKey, ChildNumber, ExtendedPubKey};
+use bitcoin::hash_types::WPubkeyHash;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use crate::{byte_utils, transaction_utils};
+use bitcoin::blockdata::opcodes;
+use bitcoin::blockdata::script::Builder;
+use lightning::chain::keysinterface::{InMemorySigner, SpendableOutputDescriptor, StaticPaymentOutputDescriptor, DelayedPaymentOutputDescriptor, KeysInterface, Sign};
+use std::collections::HashSet;
+use crate::transaction_utils::MAX_VALUE_MSAT;
+use lightning::util::ser::{Readable, Writer, Writeable};
+use lightning::ln::msgs::{DecodeError, UnsignedChannelAnnouncement};
+use bitcoin::util::bip143;
+use bitcoin::hashes::{Hash, HashEngine};
+use std::sync::Arc;
+use lightning::ln::chan_utils::{ChannelPublicKeys, CommitmentTransaction, HTLCOutputInCommitment, HolderCommitmentTransaction, ChannelTransactionParameters};
+use std::io::Error;
+
+/// Simple KeysInterface implementor that takes a 32-byte seed for use as a BIP 32 extended key
+/// and derives keys from that.
+///
+/// Your node_id is seed/0'
+/// ChannelMonitor closes may use seed/1'
+/// Cooperative closes may use seed/2'
+/// The two close keys may be needed to claim on-chain funds!
+pub struct KeysManager {
+    secp_ctx: Secp256k1<secp256k1::All>,
+    node_secret: SecretKey,
+    destination_script: Script,
+    shutdown_pubkey: PublicKey,
+    channel_master_key: ExtendedPrivKey,
+    channel_child_index: AtomicUsize,
+
+    rand_bytes_master_key: ExtendedPrivKey,
+    rand_bytes_child_index: AtomicUsize,
+    rand_bytes_unique_start: Sha256State,
+
+    seed: [u8; 32],
+    starting_time_secs: u64,
+    starting_time_nanos: u32,
+}
+
+impl KeysManager {
+    /// Constructs a KeysManager from a 32-byte seed. If the seed is in some way biased (eg your
+    /// CSRNG is busted) this may panic (but more importantly, you will possibly lose funds).
+    /// starting_time isn't strictly required to actually be a time, but it must absolutely,
+    /// without a doubt, be unique to this instance. ie if you start multiple times with the same
+    /// seed, starting_time must be unique to each run. Thus, the easiest way to achieve this is to
+    /// simply use the current time (with very high precision).
+    ///
+    /// The seed MUST be backed up safely prior to use so that the keys can be re-created, however,
+    /// obviously, starting_time should be unique every time you reload the library - it is only
+    /// used to generate new ephemeral key data (which will be stored by the individual channel if
+    /// necessary).
+    ///
+    /// Note that the seed is required to recover certain on-chain funds independent of
+    /// ChannelMonitor data, though a current copy of ChannelMonitor data is also required for any
+    /// channel, and some on-chain during-closing funds.
+    ///
+    /// Note that until the 0.1 release there is no guarantee of backward compatibility between
+    /// versions. Once the library is more fully supported, the docs will be updated to include a
+    /// detailed description of the guarantee.
+    pub fn new(seed: &[u8; 32], starting_time_secs: u64, starting_time_nanos: u32) -> Self {
+        let secp_ctx = Secp256k1::new();
+        // Note that when we aren't serializing the key, network doesn't matter
+        match ExtendedPrivKey::new_master(Network::Testnet, seed) {
+            Ok(master_key) => {
+                let node_secret = master_key.ckd_priv(&secp_ctx, ChildNumber::from_hardened_idx(0).unwrap()).expect("Your RNG is busted").private_key.key;
+                let destination_script = match master_key.ckd_priv(&secp_ctx, ChildNumber::from_hardened_idx(1).unwrap()) {
+                    Ok(destination_key) => {
+                        let wpubkey_hash = WPubkeyHash::hash(&ExtendedPubKey::from_private(&secp_ctx, &destination_key).public_key.to_bytes());
+                        Builder::new().push_opcode(opcodes::all::OP_PUSHBYTES_0)
+                            .push_slice(&wpubkey_hash.into_inner())
+                            .into_script()
+                    },
+                    Err(_) => panic!("Your RNG is busted"),
+                };
+                let shutdown_pubkey = match master_key.ckd_priv(&secp_ctx, ChildNumber::from_hardened_idx(2).unwrap()) {
+                    Ok(shutdown_key) => ExtendedPubKey::from_private(&secp_ctx, &shutdown_key).public_key.key,
+                    Err(_) => panic!("Your RNG is busted"),
+                };
+                let channel_master_key = master_key.ckd_priv(&secp_ctx, ChildNumber::from_hardened_idx(3).unwrap()).expect("Your RNG is busted");
+                let rand_bytes_master_key = master_key.ckd_priv(&secp_ctx, ChildNumber::from_hardened_idx(4).unwrap()).expect("Your RNG is busted");
+
+                let mut rand_bytes_unique_start = Sha256::engine();
+                rand_bytes_unique_start.input(&byte_utils::be64_to_array(starting_time_secs));
+                rand_bytes_unique_start.input(&byte_utils::be32_to_array(starting_time_nanos));
+                rand_bytes_unique_start.input(seed);
+
+                let mut res = KeysManager {
+                    secp_ctx,
+                    node_secret,
+
+                    destination_script,
+                    shutdown_pubkey,
+
+                    channel_master_key,
+                    channel_child_index: AtomicUsize::new(0),
+
+                    rand_bytes_master_key,
+                    rand_bytes_child_index: AtomicUsize::new(0),
+                    rand_bytes_unique_start,
+
+                    seed: *seed,
+                    starting_time_secs,
+                    starting_time_nanos,
+                };
+                let secp_seed = res.get_secure_random_bytes();
+                res.secp_ctx.seeded_randomize(&secp_seed);
+                res
+            },
+            Err(_) => panic!("Your rng is busted"),
+        }
+    }
+    /// Derive an old Sign containing per-channel secrets based on a key derivation parameters.
+    ///
+    /// Key derivation parameters are accessible through a per-channel secrets
+    /// Sign::channel_keys_id and is provided inside DynamicOuputP2WSH in case of
+    /// onchain output detection for which a corresponding delayed_payment_key must be derived.
+    pub fn derive_channel_keys(&self, channel_value_satoshis: u64, params: &[u8; 32]) -> InMemorySigner {
+        let chan_id = byte_utils::slice_to_be64(&params[0..8]);
+        assert!(chan_id <= std::u32::MAX as u64); // Otherwise the params field wasn't created by us
+        let mut unique_start = Sha256::engine();
+        unique_start.input(params);
+        unique_start.input(&self.seed);
+
+        // We only seriously intend to rely on the channel_master_key for true secure
+        // entropy, everything else just ensures uniqueness. We rely on the unique_start (ie
+        // starting_time provided in the constructor) to be unique.
+        let child_privkey = self.channel_master_key.ckd_priv(&self.secp_ctx, ChildNumber::from_hardened_idx(chan_id as u32).expect("key space exhausted")).expect("Your RNG is busted");
+        unique_start.input(&child_privkey.private_key.key[..]);
+
+        let seed = Sha256::from_engine(unique_start).into_inner();
+
+        let commitment_seed = {
+            let mut sha = Sha256::engine();
+            sha.input(&seed);
+            sha.input(&b"commitment seed"[..]);
+            Sha256::from_engine(sha).into_inner()
+        };
+        macro_rules! key_step {
+			($info: expr, $prev_key: expr) => {{
+				let mut sha = Sha256::engine();
+				sha.input(&seed);
+				sha.input(&$prev_key[..]);
+				sha.input(&$info[..]);
+				SecretKey::from_slice(&Sha256::from_engine(sha).into_inner()).expect("SHA-256 is busted")
+			}}
+		}
+        let funding_key = key_step!(b"funding key", commitment_seed);
+        let revocation_base_key = key_step!(b"revocation base key", funding_key);
+        let payment_key = key_step!(b"payment key", revocation_base_key);
+        let delayed_payment_base_key = key_step!(b"delayed payment base key", payment_key);
+        let htlc_base_key = key_step!(b"HTLC base key", delayed_payment_base_key);
+
+        InMemorySigner::new(
+            &self.secp_ctx,
+            funding_key,
+            revocation_base_key,
+            payment_key,
+            delayed_payment_base_key,
+            htlc_base_key,
+            commitment_seed,
+            channel_value_satoshis,
+            params.clone()
+        )
+    }
+
+    /// Creates a Transaction which spends the given descriptors to the given outputs, plus an
+    /// output to the given change destination (if sufficient change value remains). The
+    /// transaction will have a feerate, at least, of the given value.
+    ///
+    /// Returns `Err(())` if the output value is greater than the input value minus required fee or
+    /// if a descriptor was duplicated.
+    ///
+    /// We do not enforce that outputs meet the dust limit or that any output scripts are standard.
+    ///
+    /// May panic if the `SpendableOutputDescriptor`s were not generated by Channels which used
+    /// this KeysManager or one of the `InMemorySigner` created by this KeysManager.
+    pub fn spend_spendable_outputs<C: Signing>(&self, descriptors: &[&SpendableOutputDescriptor], outputs: Vec<TxOut>, change_destination_script: Script, feerate_sat_per_1000_weight: u32, secp_ctx: &Secp256k1<C>) -> Result<Transaction, ()> {
+        let mut input = Vec::new();
+        let mut input_value = 0;
+        let mut witness_weight = 0;
+        let mut output_set = HashSet::with_capacity(descriptors.len());
+        for outp in descriptors {
+            match outp {
+                SpendableOutputDescriptor::StaticPaymentOutput(descriptor) => {
+                    input.push(TxIn {
+                        previous_output: descriptor.outpoint.into_bitcoin_outpoint(),
+                        script_sig: Script::new(),
+                        sequence: 0,
+                        witness: Vec::new(),
+                    });
+                    witness_weight += StaticPaymentOutputDescriptor::MAX_WITNESS_LENGTH;
+                    input_value += descriptor.output.value;
+                    if !output_set.insert(descriptor.outpoint) { return Err(()); }
+                },
+                SpendableOutputDescriptor::DelayedPaymentOutput(descriptor) => {
+                    input.push(TxIn {
+                        previous_output: descriptor.outpoint.into_bitcoin_outpoint(),
+                        script_sig: Script::new(),
+                        sequence: descriptor.to_self_delay as u32,
+                        witness: Vec::new(),
+                    });
+                    witness_weight += DelayedPaymentOutputDescriptor::MAX_WITNESS_LENGTH;
+                    input_value += descriptor.output.value;
+                    if !output_set.insert(descriptor.outpoint) { return Err(()); }
+                },
+                SpendableOutputDescriptor::StaticOutput { ref outpoint, ref output } => {
+                    input.push(TxIn {
+                        previous_output: outpoint.into_bitcoin_outpoint(),
+                        script_sig: Script::new(),
+                        sequence: 0,
+                        witness: Vec::new(),
+                    });
+                    witness_weight += 1 + 73 + 34;
+                    input_value += output.value;
+                    if !output_set.insert(*outpoint) { return Err(()); }
+                }
+            }
+            if input_value > MAX_VALUE_MSAT / 1000 { return Err(()); }
+        }
+        let mut spend_tx = Transaction {
+            version: 2,
+            lock_time: 0,
+            input,
+            output: outputs,
+        };
+        transaction_utils::maybe_add_change_output(&mut spend_tx, input_value, witness_weight, feerate_sat_per_1000_weight, change_destination_script)?;
+
+        let mut keys_cache: Option<(InMemorySigner, [u8; 32])> = None;
+        let mut input_idx = 0;
+        for outp in descriptors {
+            match outp {
+                SpendableOutputDescriptor::StaticPaymentOutput(descriptor) => {
+                    if keys_cache.is_none() || keys_cache.as_ref().unwrap().1 != descriptor.channel_keys_id {
+                        keys_cache = Some((
+                            self.derive_channel_keys(descriptor.channel_value_satoshis, &descriptor.channel_keys_id),
+                            descriptor.channel_keys_id));
+                    }
+                    spend_tx.input[input_idx].witness = keys_cache.as_ref().unwrap().0.sign_counterparty_payment_input(&spend_tx, input_idx, &descriptor, &secp_ctx).unwrap();
+                },
+                SpendableOutputDescriptor::DelayedPaymentOutput(descriptor) => {
+                    if keys_cache.is_none() || keys_cache.as_ref().unwrap().1 != descriptor.channel_keys_id {
+                        keys_cache = Some((
+                            self.derive_channel_keys(descriptor.channel_value_satoshis, &descriptor.channel_keys_id),
+                            descriptor.channel_keys_id));
+                    }
+                    spend_tx.input[input_idx].witness = keys_cache.as_ref().unwrap().0.sign_dynamic_p2wsh_input(&spend_tx, input_idx, &descriptor, &secp_ctx).unwrap();
+                },
+                SpendableOutputDescriptor::StaticOutput { ref output, .. } => {
+                    let derivation_idx = if output.script_pubkey == self.destination_script {
+                        1
+                    } else {
+                        2
+                    };
+                    let secret = {
+                        // Note that when we aren't serializing the key, network doesn't matter
+                        match ExtendedPrivKey::new_master(Network::Testnet, &self.seed) {
+                            Ok(master_key) => {
+                                match master_key.ckd_priv(&secp_ctx, ChildNumber::from_hardened_idx(derivation_idx).expect("key space exhausted")) {
+                                    Ok(key) => key,
+                                    Err(_) => panic!("Your RNG is busted"),
+                                }
+                            }
+                            Err(_) => panic!("Your rng is busted"),
+                        }
+                    };
+                    let pubkey = ExtendedPubKey::from_private(&secp_ctx, &secret).public_key;
+                    if derivation_idx == 2 {
+                        assert_eq!(pubkey.key, self.shutdown_pubkey);
+                    }
+                    let witness_script = bitcoin::Address::p2pkh(&pubkey, Network::Testnet).script_pubkey();
+                    let sighash = ::bitcoin::secp256k1::Message::from_slice(&bip143::SigHashCache::new(&spend_tx).signature_hash(input_idx, &witness_script, output.value, SigHashType::All)[..]).unwrap();
+                    let sig = secp_ctx.sign(&sighash, &secret.private_key.key);
+                    spend_tx.input[input_idx].witness.push(sig.serialize_der().to_vec());
+                    spend_tx.input[input_idx].witness[0].push(SigHashType::All as u8);
+                    spend_tx.input[input_idx].witness.push(pubkey.key.serialize().to_vec());
+                },
+            }
+            input_idx += 1;
+        }
+        Ok(spend_tx)
+    }
+}
+
+impl KeysInterface for KeysManager {
+    type Signer = InMemorySigner;
+
+    fn get_node_secret(&self) -> SecretKey {
+        self.node_secret.clone()
+    }
+
+    fn get_destination_script(&self) -> Script {
+        self.destination_script.clone()
+    }
+
+    fn get_shutdown_pubkey(&self) -> PublicKey {
+        self.shutdown_pubkey.clone()
+    }
+
+    fn get_channel_signer(&self, _inbound: bool, channel_value_satoshis: u64) -> Self::Signer {
+        let child_ix = self.channel_child_index.fetch_add(1, Ordering::AcqRel);
+        assert!(child_ix <= std::u32::MAX as usize);
+        let mut id = [0; 32];
+        id[0..8].copy_from_slice(&byte_utils::be64_to_array(child_ix as u64));
+        id[8..16].copy_from_slice(&byte_utils::be64_to_array(self.starting_time_nanos as u64));
+        id[16..24].copy_from_slice(&byte_utils::be64_to_array(self.starting_time_secs));
+        self.derive_channel_keys(channel_value_satoshis, &id)
+    }
+
+    fn get_secure_random_bytes(&self) -> [u8; 32] {
+        let mut sha = self.rand_bytes_unique_start.clone();
+
+        let child_ix = self.rand_bytes_child_index.fetch_add(1, Ordering::AcqRel);
+        let child_privkey = self.rand_bytes_master_key.ckd_priv(&self.secp_ctx, ChildNumber::from_hardened_idx(child_ix as u32).expect("key space exhausted")).expect("Your RNG is busted");
+        sha.input(&child_privkey.private_key.key[..]);
+
+        sha.input(b"Unique Secure Random Bytes Salt");
+        Sha256::from_engine(sha).into_inner()
+    }
+
+    fn read_chan_signer(&self, reader: &[u8]) -> Result<Self::Signer, DecodeError> {
+        InMemorySigner::read(&mut std::io::Cursor::new(reader))
+    }
+}
+
+#[derive(Clone)]
+struct DynSigner {
+    inner: Arc<dyn Sign+Sync>,
+}
+
+impl Sign for DynSigner {
+    fn get_per_commitment_point(&self, idx: u64, secp_ctx: &Secp256k1<secp256k1::All>) -> PublicKey {
+        unimplemented!()
+    }
+
+    fn release_commitment_secret(&self, idx: u64) -> [u8; 32] {
+        unimplemented!()
+    }
+
+    fn pubkeys(&self) -> &ChannelPublicKeys {
+        unimplemented!()
+    }
+
+    fn channel_keys_id(&self) -> [u8; 32] {
+        unimplemented!()
+    }
+
+    fn sign_counterparty_commitment(&self, commitment_tx: &CommitmentTransaction, secp_ctx: &Secp256k1<secp256k1::All>) -> Result<(Signature, Vec<Signature>), ()> {
+        unimplemented!()
+    }
+
+    fn sign_holder_commitment_and_htlcs(&self, commitment_tx: &HolderCommitmentTransaction, secp_ctx: &Secp256k1<secp256k1::All>) -> Result<(Signature, Vec<Signature>), ()> {
+        unimplemented!()
+    }
+
+    fn sign_justice_transaction(&self, justice_tx: &Transaction, input: usize, amount: u64, per_commitment_key: &SecretKey, htlc: &Option<HTLCOutputInCommitment>, secp_ctx: &Secp256k1<secp256k1::All>) -> Result<Signature, ()> {
+        unimplemented!()
+    }
+
+    fn sign_counterparty_htlc_transaction(&self, htlc_tx: &Transaction, input: usize, amount: u64, per_commitment_point: &PublicKey, htlc: &HTLCOutputInCommitment, secp_ctx: &Secp256k1<secp256k1::All>) -> Result<Signature, ()> {
+        unimplemented!()
+    }
+
+    fn sign_closing_transaction(&self, closing_tx: &Transaction, secp_ctx: &Secp256k1<secp256k1::All>) -> Result<Signature, ()> {
+        unimplemented!()
+    }
+
+    fn sign_channel_announcement(&self, msg: &UnsignedChannelAnnouncement, secp_ctx: &Secp256k1<secp256k1::All>) -> Result<Signature, ()> {
+        unimplemented!()
+    }
+
+    fn ready_channel(&mut self, channel_parameters: &ChannelTransactionParameters) {
+        unimplemented!()
+    }
+}
+
+impl Writeable for DynSigner {
+    fn write(&self, writer: &mut Writer) -> Result<(), Error> {
+        unimplemented!()
+    }
+}
+
+struct DynKeysManager {
+    inner: Arc<dyn KeysInterface<Signer=DynSigner>>
+}
+
+impl KeysInterface for DynKeysManager {
+    type Signer = DynSigner;
+
+    fn get_node_secret(&self) -> SecretKey {
+        unimplemented!()
+    }
+
+    fn get_destination_script(&self) -> Script {
+        unimplemented!()
+    }
+
+    fn get_shutdown_pubkey(&self) -> PublicKey {
+        unimplemented!()
+    }
+
+    fn get_channel_signer(&self, inbound: bool, channel_value_satoshis: u64) -> Self::Signer {
+        unimplemented!()
+    }
+
+    fn get_secure_random_bytes(&self) -> [u8; 32] {
+        unimplemented!()
+    }
+
+    fn read_chan_signer(&self, reader: &[u8]) -> Result<Self::Signer, DecodeError> {
+        unimplemented!()
+    }
+}

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -31,6 +31,9 @@ pub trait SpendableKeysInterface : KeysInterface {
     fn spend_spendable_outputs(&self, descriptors: &[&SpendableOutputDescriptor], outputs: Vec<TxOut>, change_destination_script: Script, feerate_sat_per_1000_weight: u32, secp_ctx: &Secp256k1<All>) -> Result<Transaction, ()>;
 }
 
+pub trait DynKeysInterface : SpendableKeysInterface<Signer=DynSigner> {
+}
+
 // XXX copied from keysinterface.rs and decoupled from InMemorySigner
 // XXX parametrized by SignerFactory
 
@@ -181,6 +184,9 @@ impl<F: SignerFactory> KeysInterface for KeysManager<F> {
     fn read_chan_signer(&self, reader: &[u8]) -> Result<Self::Signer, DecodeError> {
         DynSigner::read(&mut std::io::Cursor::new(reader))
     }
+}
+
+impl<F: SignerFactory> DynKeysInterface for KeysManager<F> {
 }
 
 impl<F: SignerFactory> SpendableKeysInterface for KeysManager<F> {

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -316,11 +316,11 @@ pub trait PaymentSign: Sign {
 
 // XXX helper to allow DynSigner to clone itself
 pub trait InnerSign: PaymentSign {
-    fn box_clone(&self) -> Box<dyn InnerSign + Sync>;
+    fn box_clone(&self) -> Box<dyn InnerSign>;
 }
 
 pub struct DynSigner {
-    pub inner: Box<dyn InnerSign + Sync>,
+    pub inner: Box<dyn InnerSign>,
 }
 
 impl Clone for DynSigner {

--- a/src/transaction_utils.rs
+++ b/src/transaction_utils.rs
@@ -1,0 +1,49 @@
+use bitcoin::{Transaction, Script, TxOut, VarInt};
+use bitcoin::consensus::Encodable;
+
+pub(crate) const MAX_VALUE_MSAT: u64 = 21_000_000_0000_0000_000;
+
+fn get_dust_value(output_script: &Script) -> u64 {
+    //TODO: This belongs in rust-bitcoin (https://github.com/rust-bitcoin/rust-bitcoin/pull/566)
+    if output_script.is_op_return() {
+        0
+    } else if output_script.is_witness_program() {
+        294
+    } else {
+        546
+    }
+}
+
+/// Possibly adds a change output to the given transaction, always doing so if there are excess
+/// funds available beyond the requested feerate.
+/// Assumes at least one input will have a witness (ie spends a segwit output).
+/// Returns an Err(()) if the requested feerate cannot be met.
+pub(crate) fn maybe_add_change_output(tx: &mut Transaction, input_value: u64, witness_max_weight: usize, feerate_sat_per_1000_weight: u32, change_destination_script: Script) -> Result<(), ()> {
+    if input_value > MAX_VALUE_MSAT / 1000 { return Err(()); }
+
+    let mut output_value = 0;
+    for output in tx.output.iter() {
+        output_value += output.value;
+        if output_value >= input_value { return Err(()); }
+    }
+
+    let dust_value = get_dust_value(&change_destination_script);
+    let mut change_output = TxOut {
+        script_pubkey: change_destination_script,
+        value: 0,
+    };
+    let change_len = change_output.consensus_encode(&mut std::io::sink()).unwrap();
+    let mut weight_with_change: i64 = tx.get_weight() as i64 + 2 + witness_max_weight as i64 + change_len as i64 * 4;
+    // Include any extra bytes required to push an extra output.
+    weight_with_change += (VarInt(tx.output.len() as u64 + 1).len() - VarInt(tx.output.len() as u64).len()) as i64 * 4;
+    // When calculating weight, add two for the flag bytes
+    let change_value: i64 = (input_value - output_value) as i64 - weight_with_change * feerate_sat_per_1000_weight as i64 / 1000;
+    if change_value >= dust_value as i64 {
+        change_output.value = change_value as u64;
+        tx.output.push(change_output);
+    } else if (input_value - output_value) as i64 - (tx.get_weight() as i64 + 2 + witness_max_weight as i64) * feerate_sat_per_1000_weight as i64 / 1000 < 0 {
+        return Err(());
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This PR experiments with making the `Sign` and `KeysInterface` implementations more easily pluggable by making them `dyn`.

This works with this follow rust-lightning PR: https://github.com/rust-bitcoin/rust-lightning/pull/861

(note that the initial attempt was using generics, but this was later changed to `dyn`)

Points for discussion marked with `XXX` (but beware of github collapsing files when searching for this pattern).